### PR TITLE
Rw 27: Added kilometer price and sinpe data object to configItem

### DIFF
--- a/docs/enums/FirestoreCollections.md
+++ b/docs/enums/FirestoreCollections.md
@@ -30,7 +30,7 @@ Coleccion de [AdminUser](../interfaces/AdminUser.md)
 
 #### Defined in
 
-[index.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L29)
+[index.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L29)
 
 ___
 
@@ -42,7 +42,7 @@ Coleccion de [AverageRating](../interfaces/AverageRating.md)
 
 #### Defined in
 
-[index.ts:47](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L47)
+[index.ts:47](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L47)
 
 ___
 
@@ -54,7 +54,7 @@ Coleccion de [Biker](../interfaces/Biker.md)
 
 #### Defined in
 
-[index.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L32)
+[index.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L32)
 
 ___
 
@@ -66,7 +66,7 @@ Coleccion de [Business](../interfaces/Business.md)
 
 #### Defined in
 
-[index.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L35)
+[index.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L35)
 
 ___
 
@@ -78,7 +78,7 @@ Coleccion de [ConfigItem](../interfaces/ConfigItem.md)
 
 #### Defined in
 
-[index.ts:59](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L59)
+[index.ts:59](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L59)
 
 ___
 
@@ -90,7 +90,7 @@ Coleccion de [Customer](../interfaces/Customer.md)
 
 #### Defined in
 
-[index.ts:38](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L38)
+[index.ts:38](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L38)
 
 ___
 
@@ -102,7 +102,7 @@ Coleccion de [DeliveryAvailable](../interfaces/DeliveryAvailable.md)
 
 #### Defined in
 
-[index.ts:50](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L50)
+[index.ts:50](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L50)
 
 ___
 
@@ -114,7 +114,7 @@ Coleccion de [Order](../interfaces/Order.md)
 
 #### Defined in
 
-[index.ts:41](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L41)
+[index.ts:41](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L41)
 
 ___
 
@@ -126,7 +126,7 @@ Coleccion de [Product](../interfaces/Product.md)
 
 #### Defined in
 
-[index.ts:53](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L53)
+[index.ts:53](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L53)
 
 ___
 
@@ -138,7 +138,7 @@ Coleccion de [Rating](../interfaces/Rating.md)
 
 #### Defined in
 
-[index.ts:44](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L44)
+[index.ts:44](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L44)
 
 ___
 
@@ -150,4 +150,4 @@ Coleccion de [Tag](../interfaces/Tag.md)
 
 #### Defined in
 
-[index.ts:56](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/index.ts#L56)
+[index.ts:56](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/index.ts#L56)

--- a/docs/interfaces/AdminUser.md
+++ b/docs/interfaces/AdminUser.md
@@ -28,7 +28,7 @@ rol del admin - ver [AdminRole](../modules.md#adminrole)
 
 #### Defined in
 
-[src/admin/admin.ts:28](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L28)
+[src/admin/admin.ts:28](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L28)
 
 ___
 
@@ -40,7 +40,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/admin/admin.ts:31](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L31)
+[src/admin/admin.ts:31](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L31)
 
 ___
 
@@ -52,7 +52,7 @@ correo electronico
 
 #### Defined in
 
-[src/admin/admin.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L22)
+[src/admin/admin.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L22)
 
 ___
 
@@ -64,7 +64,7 @@ id de firebase auth
 
 #### Defined in
 
-[src/admin/admin.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L13)
+[src/admin/admin.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L13)
 
 ___
 
@@ -76,7 +76,7 @@ nombre
 
 #### Defined in
 
-[src/admin/admin.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L16)
+[src/admin/admin.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L16)
 
 ___
 
@@ -88,7 +88,7 @@ apellidos
 
 #### Defined in
 
-[src/admin/admin.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L19)
+[src/admin/admin.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L19)
 
 ___
 
@@ -100,7 +100,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/admin/admin.ts:34](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L34)
+[src/admin/admin.ts:34](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L34)
 
 ___
 
@@ -112,7 +112,7 @@ URL de la foto de perfil (almacenada en Firebase Storage)
 
 #### Defined in
 
-[src/admin/admin.ts:25](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L25)
+[src/admin/admin.ts:25](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L25)
 
 ___
 
@@ -124,4 +124,4 @@ estado de la cuenta de usario administrado (si fue o no aprobado por un usuario 
 
 #### Defined in
 
-[src/admin/admin.ts:37](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L37)
+[src/admin/admin.ts:37](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L37)

--- a/docs/interfaces/AverageRating.md
+++ b/docs/interfaces/AverageRating.md
@@ -25,7 +25,7 @@ Puntaje promedio => sumOfRatings / numberOfRatings
 
 #### Defined in
 
-[src/rating/averageRating.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/averageRating.ts#L20)
+[src/rating/averageRating.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/averageRating.ts#L20)
 
 ___
 
@@ -37,7 +37,7 @@ Cantidad de ratings asignados a este usuario
 
 #### Defined in
 
-[src/rating/averageRating.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/averageRating.ts#L17)
+[src/rating/averageRating.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/averageRating.ts#L17)
 
 ___
 
@@ -49,7 +49,7 @@ Firebase User Id del usuario calificado (de firebase auth).
 
 #### Defined in
 
-[src/rating/averageRating.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/averageRating.ts#L8)
+[src/rating/averageRating.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/averageRating.ts#L8)
 
 ___
 
@@ -61,7 +61,7 @@ Tipo del usuario calificado (customer, business, biker, etc.).
 
 #### Defined in
 
-[src/rating/averageRating.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/averageRating.ts#L11)
+[src/rating/averageRating.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/averageRating.ts#L11)
 
 ___
 
@@ -73,4 +73,4 @@ Suma total de todos los ratings asignados a este usuario
 
 #### Defined in
 
-[src/rating/averageRating.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/averageRating.ts#L14)
+[src/rating/averageRating.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/averageRating.ts#L14)

--- a/docs/interfaces/Biker.md
+++ b/docs/interfaces/Biker.md
@@ -30,7 +30,7 @@ Representa un usuario ciclista del sistema
 
 #### Defined in
 
-[src/biker/biker.ts:33](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L33)
+[src/biker/biker.ts:33](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L33)
 
 ___
 
@@ -42,7 +42,7 @@ numero de celular
 
 #### Defined in
 
-[src/biker/biker.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L23)
+[src/biker/biker.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L23)
 
 ___
 
@@ -54,7 +54,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/biker/biker.ts:38](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L38)
+[src/biker/biker.ts:38](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L38)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/biker/biker.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L35)
+[src/biker/biker.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L35)
 
 ___
 
@@ -76,7 +76,7 @@ correo electronico
 
 #### Defined in
 
-[src/biker/biker.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L20)
+[src/biker/biker.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L20)
 
 ___
 
@@ -88,7 +88,7 @@ id de firebase auth
 
 #### Defined in
 
-[src/biker/biker.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L11)
+[src/biker/biker.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L11)
 
 ___
 
@@ -100,7 +100,7 @@ nombre
 
 #### Defined in
 
-[src/biker/biker.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L14)
+[src/biker/biker.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L14)
 
 ___
 
@@ -112,7 +112,7 @@ apellidos
 
 #### Defined in
 
-[src/biker/biker.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L17)
+[src/biker/biker.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L17)
 
 ___
 
@@ -124,7 +124,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/biker/biker.ts:41](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L41)
+[src/biker/biker.ts:41](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L41)
 
 ___
 
@@ -136,7 +136,7 @@ URL de la foto de perfil (almacenada en Firebase Storage)
 
 #### Defined in
 
-[src/biker/biker.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L26)
+[src/biker/biker.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L26)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[src/biker/biker.ts:31](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L31)
+[src/biker/biker.ts:31](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L31)
 
 ___
 
@@ -158,7 +158,7 @@ status del ciclista, relacionado con la capacidad de recibir ordenes - ver [Bike
 
 #### Defined in
 
-[src/biker/biker.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L29)
+[src/biker/biker.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L29)
 
 ___
 
@@ -170,4 +170,4 @@ estado de la cuenta de usario ciclista (si fue o no aprobado por un usuario admi
 
 #### Defined in
 
-[src/biker/biker.ts:44](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L44)
+[src/biker/biker.ts:44](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L44)

--- a/docs/interfaces/Business.md
+++ b/docs/interfaces/Business.md
@@ -34,7 +34,7 @@ Representa un usuario de un negocio del sistema
 
 #### Defined in
 
-[src/business/business.ts:34](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L34)
+[src/business/business.ts:34](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L34)
 
 ___
 
@@ -46,7 +46,7 @@ numero de celular del negocio
 
 #### Defined in
 
-[src/business/business.ts:30](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L30)
+[src/business/business.ts:30](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L30)
 
 ___
 
@@ -58,7 +58,7 @@ contactos extra fuera del correo y telefono - ver [BusinessContact](BusinessCont
 
 #### Defined in
 
-[src/business/business.ts:51](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L51)
+[src/business/business.ts:51](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L51)
 
 ___
 
@@ -70,7 +70,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/business/business.ts:63](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L63)
+[src/business/business.ts:63](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L63)
 
 ___
 
@@ -82,7 +82,7 @@ ubicacion actual del negocio, utilizado para calcular rutas de los envios
 
 #### Defined in
 
-[src/business/business.ts:42](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L42)
+[src/business/business.ts:42](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ descripcion del negocio
 
 #### Defined in
 
-[src/business/business.ts:57](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L57)
+[src/business/business.ts:57](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L57)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[src/business/business.ts:36](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L36)
+[src/business/business.ts:36](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L36)
 
 ___
 
@@ -116,7 +116,7 @@ correo electronico del negocio
 
 #### Defined in
 
-[src/business/business.ts:54](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L54)
+[src/business/business.ts:54](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L54)
 
 ___
 
@@ -128,7 +128,7 @@ id de firebase auth
 
 #### Defined in
 
-[src/business/business.ts:21](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L21)
+[src/business/business.ts:21](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L21)
 
 ___
 
@@ -140,7 +140,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/business/business.ts:66](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L66)
+[src/business/business.ts:66](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L66)
 
 ___
 
@@ -152,7 +152,7 @@ nombre del negocio
 
 #### Defined in
 
-[src/business/business.ts:27](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L27)
+[src/business/business.ts:27](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L27)
 
 ___
 
@@ -164,7 +164,7 @@ otras señas de la direccion del negocio
 
 #### Defined in
 
-[src/business/business.ts:39](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L39)
+[src/business/business.ts:39](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L39)
 
 ___
 
@@ -176,7 +176,7 @@ URL de la foto de perfil (almacenada en Firebase Storage)
 
 #### Defined in
 
-[src/business/business.ts:24](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L24)
+[src/business/business.ts:24](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L24)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[src/business/business.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L32)
+[src/business/business.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L32)
 
 ___
 
@@ -198,7 +198,7 @@ promedio de ratings del negocio
 
 #### Defined in
 
-[src/business/business.ts:48](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L48)
+[src/business/business.ts:48](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L48)
 
 ___
 
@@ -210,7 +210,7 @@ Lista de tags a las que pertenece este negocio - ver [Tag](Tag.md)
 
 #### Defined in
 
-[src/business/business.ts:60](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L60)
+[src/business/business.ts:60](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L60)
 
 ___
 
@@ -222,4 +222,4 @@ estado de la cuenta de usario de un negocio (si fue o no aprobado por un usuario
 
 #### Defined in
 
-[src/business/business.ts:45](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L45)
+[src/business/business.ts:45](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L45)

--- a/docs/interfaces/BusinessContact.md
+++ b/docs/interfaces/BusinessContact.md
@@ -21,7 +21,7 @@ tipo del contacto - ver [BusinessContact](BusinessContact.md)
 
 #### Defined in
 
-[src/business/business.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L10)
+[src/business/business.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L10)
 
 ___
 
@@ -33,4 +33,4 @@ url del contacto
 
 #### Defined in
 
-[src/business/business.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L13)
+[src/business/business.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L13)

--- a/docs/interfaces/ConfigItem.md
+++ b/docs/interfaces/ConfigItem.md
@@ -12,9 +12,11 @@ Configuración general sobre RIDE
 - [email](ConfigItem.md#email)
 - [facebook](ConfigItem.md#facebook)
 - [instragram](ConfigItem.md#instragram)
+- [kilometerPrice](ConfigItem.md#kilometerprice)
 - [name](ConfigItem.md#name)
 - [phoneEmergency](ConfigItem.md#phoneemergency)
 - [phoneInformation](ConfigItem.md#phoneinformation)
+- [sinpeData](ConfigItem.md#sinpedata)
 
 ## Properties
 
@@ -26,7 +28,7 @@ da información sobre la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L7)
+[src/admin/configItem.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L7)
 
 ___
 
@@ -38,7 +40,7 @@ correo electrónico oficial de la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L16)
+[src/admin/configItem.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L16)
 
 ___
 
@@ -50,7 +52,7 @@ URL de facebook oficial de la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L19)
+[src/admin/configItem.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L19)
 
 ___
 
@@ -62,7 +64,19 @@ URL de instagram oficial de la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L22)
+[src/admin/configItem.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L22)
+
+___
+
+### kilometerPrice
+
+• **kilometerPrice**: `number`
+
+valor real del monto que se cobra por kilómetro
+
+#### Defined in
+
+[src/admin/configItem.ts:28](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L28)
 
 ___
 
@@ -74,7 +88,7 @@ nombre de la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:4](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L4)
+[src/admin/configItem.ts:4](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L4)
 
 ___
 
@@ -86,7 +100,7 @@ número de emergencia para comunicarse con RIDE dashboard
 
 #### Defined in
 
-[src/admin/configItem.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L10)
+[src/admin/configItem.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L10)
 
 ___
 
@@ -98,4 +112,16 @@ número para obtener información sobre la aplicación RIDE
 
 #### Defined in
 
-[src/admin/configItem.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/configItem.ts#L13)
+[src/admin/configItem.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L13)
+
+___
+
+### sinpeData
+
+• **sinpeData**: [`SinpeData`](SinpeData.md)
+
+objeto con los datos de sinpe móvil - ver [SinpeData](SinpeData.md)
+
+#### Defined in
+
+[src/admin/configItem.ts:25](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L25)

--- a/docs/interfaces/Coords.md
+++ b/docs/interfaces/Coords.md
@@ -19,7 +19,7 @@ Coordenadas
 
 #### Defined in
 
-[src/other/shared.ts:12](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/shared.ts#L12)
+[src/other/shared.ts:12](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/shared.ts#L12)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[src/other/shared.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/shared.ts#L11)
+[src/other/shared.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/shared.ts#L11)

--- a/docs/interfaces/Customer.md
+++ b/docs/interfaces/Customer.md
@@ -29,7 +29,7 @@ numero de celular del usuario
 
 #### Defined in
 
-[src/customer/customer.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L23)
+[src/customer/customer.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/customer/customer.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L32)
+[src/customer/customer.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L32)
 
 ___
 
@@ -53,7 +53,7 @@ ubicacion actual del negocio, utilizado para calcular rutas de los envios
 
 #### Defined in
 
-[src/customer/customer.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L29)
+[src/customer/customer.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L29)
 
 ___
 
@@ -65,7 +65,7 @@ correo electronico del usuario
 
 #### Defined in
 
-[src/customer/customer.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L14)
+[src/customer/customer.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L14)
 
 ___
 
@@ -77,7 +77,7 @@ token para los mensajes de la nube
 
 #### Defined in
 
-[src/customer/customer.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L20)
+[src/customer/customer.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L20)
 
 ___
 
@@ -89,7 +89,7 @@ id de firebase auth
 
 #### Defined in
 
-[src/customer/customer.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L17)
+[src/customer/customer.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L17)
 
 ___
 
@@ -101,7 +101,7 @@ nombre completo del usuario
 
 #### Defined in
 
-[src/customer/customer.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L8)
+[src/customer/customer.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L8)
 
 ___
 
@@ -113,7 +113,7 @@ apellidos del usuario
 
 #### Defined in
 
-[src/customer/customer.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L11)
+[src/customer/customer.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L11)
 
 ___
 
@@ -125,7 +125,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/customer/customer.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L35)
+[src/customer/customer.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L35)
 
 ___
 
@@ -137,4 +137,4 @@ URL de la foto de perfil (almacenada en Firebase Storage)
 
 #### Defined in
 
-[src/customer/customer.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/customer/customer.ts#L26)
+[src/customer/customer.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/customer/customer.ts#L26)

--- a/docs/interfaces/DeliveryAvailable.md
+++ b/docs/interfaces/DeliveryAvailable.md
@@ -23,7 +23,7 @@ Lista de IDs de los ciclistas a los que se les asigna la entrega como disponible
 
 #### Defined in
 
-[src/other/deliveryAvailable.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/deliveryAvailable.ts#L11)
+[src/other/deliveryAvailable.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/deliveryAvailable.ts#L11)
 
 ___
 
@@ -35,4 +35,4 @@ Id de la orden
 
 #### Defined in
 
-[src/other/deliveryAvailable.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/deliveryAvailable.ts#L8)
+[src/other/deliveryAvailable.ts:8](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/deliveryAvailable.ts#L8)

--- a/docs/interfaces/Order.md
+++ b/docs/interfaces/Order.md
@@ -39,7 +39,7 @@ Firebase User Id del biker (de firebase auth)
 
 #### Defined in
 
-[src/order/order.ts:82](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L82)
+[src/order/order.ts:82](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L82)
 
 ___
 
@@ -51,7 +51,7 @@ Firebase User Id del negocio (de firebase auth)
 
 #### Defined in
 
-[src/order/order.ts:79](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L79)
+[src/order/order.ts:79](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L79)
 
 ___
 
@@ -63,7 +63,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/order/order.ts:118](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L118)
+[src/order/order.ts:118](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L118)
 
 ___
 
@@ -75,7 +75,7 @@ nombre completo del cliente
 
 #### Defined in
 
-[src/order/order.ts:127](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L127)
+[src/order/order.ts:127](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L127)
 
 ___
 
@@ -87,7 +87,7 @@ Firebase User Id del usuario (de firebase auth)
 
 #### Defined in
 
-[src/order/order.ts:76](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L76)
+[src/order/order.ts:76](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L76)
 
 ___
 
@@ -99,7 +99,7 @@ apellidos del cliente
 
 #### Defined in
 
-[src/order/order.ts:130](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L130)
+[src/order/order.ts:130](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L130)
 
 ___
 
@@ -111,7 +111,7 @@ coordenadas de le entrega (se sacan de la ubicacion actual del Customer)
 
 #### Defined in
 
-[src/order/order.ts:121](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L121)
+[src/order/order.ts:121](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L121)
 
 ___
 
@@ -123,7 +123,7 @@ Direccion de entrega de la orden
 
 #### Defined in
 
-[src/order/order.ts:106](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L106)
+[src/order/order.ts:106](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L106)
 
 ___
 
@@ -135,7 +135,7 @@ Distancia entre la direccion de origen y destino
 
 #### Defined in
 
-[src/order/order.ts:112](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L112)
+[src/order/order.ts:112](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L112)
 
 ___
 
@@ -147,7 +147,7 @@ lista de items en la orden - ver [OrderItem](OrderItem.md)
 
 #### Defined in
 
-[src/order/order.ts:91](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L91)
+[src/order/order.ts:91](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L91)
 
 ___
 
@@ -159,7 +159,7 @@ Costo de los items de la orden (sin envio)
 
 #### Defined in
 
-[src/order/order.ts:97](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L97)
+[src/order/order.ts:97](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L97)
 
 ___
 
@@ -171,7 +171,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/order/order.ts:124](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L124)
+[src/order/order.ts:124](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L124)
 
 ___
 
@@ -183,7 +183,7 @@ Metodo de pago de la orden - ver [PaymentMethod](../modules.md#paymentmethod)
 
 #### Defined in
 
-[src/order/order.ts:88](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L88)
+[src/order/order.ts:88](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L88)
 
 ___
 
@@ -195,7 +195,7 @@ Direccion de origen de la orden
 
 #### Defined in
 
-[src/order/order.ts:109](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L109)
+[src/order/order.ts:109](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L109)
 
 ___
 
@@ -207,7 +207,7 @@ Calificanes de las órdenes
 
 #### Defined in
 
-[src/order/order.ts:115](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L115)
+[src/order/order.ts:115](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L115)
 
 ___
 
@@ -219,7 +219,7 @@ Reporte del ciclista
 
 #### Defined in
 
-[src/order/order.ts:133](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L133)
+[src/order/order.ts:133](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L133)
 
 ___
 
@@ -231,7 +231,7 @@ Costo del envio
 
 #### Defined in
 
-[src/order/order.ts:100](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L100)
+[src/order/order.ts:100](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L100)
 
 ___
 
@@ -243,7 +243,7 @@ Status de la orden - ver [OrderStatus](../modules.md#orderstatus)
 
 #### Defined in
 
-[src/order/order.ts:85](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L85)
+[src/order/order.ts:85](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L85)
 
 ___
 
@@ -255,7 +255,7 @@ Propina para el ciclista
 
 #### Defined in
 
-[src/order/order.ts:103](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L103)
+[src/order/order.ts:103](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L103)
 
 ___
 
@@ -267,4 +267,4 @@ Costo total de la orden
 
 #### Defined in
 
-[src/order/order.ts:94](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L94)
+[src/order/order.ts:94](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L94)

--- a/docs/interfaces/OrderItem.md
+++ b/docs/interfaces/OrderItem.md
@@ -25,7 +25,7 @@ costo del producto
 
 #### Defined in
 
-[src/order/order.ts:66](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L66)
+[src/order/order.ts:66](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L66)
 
 ___
 
@@ -37,7 +37,7 @@ nombre del producto
 
 #### Defined in
 
-[src/order/order.ts:64](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L64)
+[src/order/order.ts:64](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L64)
 
 ___
 
@@ -49,7 +49,7 @@ notas para el producto dentro de la orden
 
 #### Defined in
 
-[src/order/order.ts:68](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L68)
+[src/order/order.ts:68](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L68)
 
 ___
 
@@ -61,4 +61,4 @@ Id del producto (de la coleccion de productos - puede ser de un producto borrado
 
 #### Defined in
 
-[src/order/order.ts:62](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L62)
+[src/order/order.ts:62](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L62)

--- a/docs/interfaces/Product.md
+++ b/docs/interfaces/Product.md
@@ -31,7 +31,7 @@ Firebase User Id del negocio (de firebase auth)
 
 #### Defined in
 
-[src/product/product.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L20)
+[src/product/product.ts:20](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L20)
 
 ___
 
@@ -43,7 +43,7 @@ Costo unitario del producto
 
 #### Defined in
 
-[src/product/product.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L17)
+[src/product/product.ts:17](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L17)
 
 ___
 
@@ -55,7 +55,7 @@ fecha y hora de creacion
 
 #### Defined in
 
-[src/product/product.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L29)
+[src/product/product.ts:29](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L29)
 
 ___
 
@@ -67,7 +67,7 @@ Indica si el producto fue borrado o no
 
 #### Defined in
 
-[src/product/product.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L35)
+[src/product/product.ts:35](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L35)
 
 ___
 
@@ -79,7 +79,7 @@ Descripcion del producto
 
 #### Defined in
 
-[src/product/product.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L14)
+[src/product/product.ts:14](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L14)
 
 ___
 
@@ -91,7 +91,7 @@ fecha y hora de ultima actualizacion
 
 #### Defined in
 
-[src/product/product.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L32)
+[src/product/product.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L32)
 
 ___
 
@@ -103,7 +103,7 @@ Nombre del producto
 
 #### Defined in
 
-[src/product/product.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L11)
+[src/product/product.ts:11](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L11)
 
 ___
 
@@ -115,7 +115,7 @@ URL de la foto de producto (almacenada en Firebase Storage)
 
 #### Defined in
 
-[src/product/product.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L26)
+[src/product/product.ts:26](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L26)
 
 ___
 
@@ -127,4 +127,4 @@ Lista de Etiquetas a las que pertenece el producto - ver [Tag](Tag.md)
 
 #### Defined in
 
-[src/product/product.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/product.ts#L23)
+[src/product/product.ts:23](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/product.ts#L23)

--- a/docs/interfaces/Rating.md
+++ b/docs/interfaces/Rating.md
@@ -25,7 +25,7 @@ Comentario recibido
 
 #### Defined in
 
-[src/rating/rating.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L16)
+[src/rating/rating.ts:16](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L16)
 
 ___
 
@@ -37,7 +37,7 @@ Firebase User Id del usuario calificado (de firebase auth).
 
 #### Defined in
 
-[src/rating/rating.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L19)
+[src/rating/rating.ts:19](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L19)
 
 ___
 
@@ -49,7 +49,7 @@ Tipo del usuario calificado (customer, business, biker, etc.).
 
 #### Defined in
 
-[src/rating/rating.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L22)
+[src/rating/rating.ts:22](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L22)
 
 ___
 
@@ -61,7 +61,7 @@ Firebase User Id del usuario que proporcionó el rating
 
 #### Defined in
 
-[src/rating/rating.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L7)
+[src/rating/rating.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L7)
 
 ___
 
@@ -73,7 +73,7 @@ Tipo del usuario que proporcionó el rating
 
 #### Defined in
 
-[src/rating/rating.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L10)
+[src/rating/rating.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L10)
 
 ___
 
@@ -85,4 +85,4 @@ Valor numérico del rating (puede ser una puntuación, estrella, etc.)
 
 #### Defined in
 
-[src/rating/rating.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/rating/rating.ts#L13)
+[src/rating/rating.ts:13](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/rating/rating.ts#L13)

--- a/docs/interfaces/SinpeData.md
+++ b/docs/interfaces/SinpeData.md
@@ -1,0 +1,62 @@
+[ride-dbtypes](../README.md) / [Exports](../modules.md) / SinpeData
+
+# Interface: SinpeData
+
+Representa la información de sinpe móvil donde el usuario puede realizar el pago
+
+## Table of contents
+
+### Properties
+
+- [firstName](SinpeData.md#firstname)
+- [lastName](SinpeData.md#lastname)
+- [ownerId](SinpeData.md#ownerid)
+- [phoneNumber](SinpeData.md#phonenumber)
+
+## Properties
+
+### firstName
+
+• **firstName**: `string`
+
+nombre de la persona dueña de la cuenta
+
+#### Defined in
+
+[src/admin/configItem.ts:39](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L39)
+
+___
+
+### lastName
+
+• **lastName**: `string`
+
+apellidos de la persona dueña de la cuenta
+
+#### Defined in
+
+[src/admin/configItem.ts:42](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L42)
+
+___
+
+### ownerId
+
+• **ownerId**: `string`
+
+cédula jurídica, física, dimex o otras de la persona dueña de la cuenta
+
+#### Defined in
+
+[src/admin/configItem.ts:36](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L36)
+
+___
+
+### phoneNumber
+
+• **phoneNumber**: `string`
+
+número de teléfono a al que está asociada la cuenta
+
+#### Defined in
+
+[src/admin/configItem.ts:45](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/configItem.ts#L45)

--- a/docs/interfaces/Tag.md
+++ b/docs/interfaces/Tag.md
@@ -22,7 +22,7 @@ descripcion corta del tag (e.g. comida circular con queso y tomate)
 
 #### Defined in
 
-[src/product/tag.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/tag.ts#L10)
+[src/product/tag.ts:10](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/tag.ts#L10)
 
 ___
 
@@ -34,4 +34,4 @@ nombre del tag (e.g. pizza)
 
 #### Defined in
 
-[src/product/tag.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/product/tag.ts#L7)
+[src/product/tag.ts:7](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/product/tag.ts#L7)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -23,6 +23,7 @@
 - [OrderItem](interfaces/OrderItem.md)
 - [Product](interfaces/Product.md)
 - [Rating](interfaces/Rating.md)
+- [SinpeData](interfaces/SinpeData.md)
 - [Tag](interfaces/Tag.md)
 
 ### Type aliases
@@ -50,7 +51,7 @@ Tipo de usuario adminsitrador
 
 #### Defined in
 
-[src/admin/admin.ts:6](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/admin/admin.ts#L6)
+[src/admin/admin.ts:6](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/admin/admin.ts#L6)
 
 ___
 
@@ -62,7 +63,7 @@ Si el usuario ciclista esta disponible o no para hacer entregas
 
 #### Defined in
 
-[src/biker/biker.ts:4](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/biker/biker.ts#L4)
+[src/biker/biker.ts:4](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/biker/biker.ts#L4)
 
 ___
 
@@ -74,7 +75,7 @@ tipo del contacto adicional, como redes sociales o sitio web
 
 #### Defined in
 
-[src/business/business.ts:5](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/business/business.ts#L5)
+[src/business/business.ts:5](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/business/business.ts#L5)
 
 ___
 
@@ -97,7 +98,7 @@ Canceled: el pedido es cancelado por el administrador
 
 #### Defined in
 
-[src/order/order.ts:18](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L18)
+[src/order/order.ts:18](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L18)
 
 ___
 
@@ -109,7 +110,7 @@ Metodos de pago
 
 #### Defined in
 
-[src/order/order.ts:47](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L47)
+[src/order/order.ts:47](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L47)
 
 ___
 
@@ -122,7 +123,7 @@ Bikers, Admin y Business
 
 #### Defined in
 
-[src/other/shared.ts:5](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/shared.ts#L5)
+[src/other/shared.ts:5](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/shared.ts#L5)
 
 ___
 
@@ -132,7 +133,7 @@ ___
 
 #### Defined in
 
-[src/other/shared.ts:15](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/other/shared.ts#L15)
+[src/other/shared.ts:15](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/other/shared.ts#L15)
 
 ## Variables
 
@@ -144,7 +145,7 @@ Métodos de pago en español
 
 #### Defined in
 
-[src/order/order.ts:50](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L50)
+[src/order/order.ts:50](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L50)
 
 ___
 
@@ -156,4 +157,4 @@ Status de la Orden en español
 
 #### Defined in
 
-[src/order/order.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/77ee6f4/src/order/order.ts#L32)
+[src/order/order.ts:32](https://github.com/gatitolabs/ride-dbtypes/blob/c1fc7c5/src/order/order.ts#L32)

--- a/index.ts
+++ b/index.ts
@@ -12,16 +12,14 @@ export {
   OrderStatus,
   PaymentMethod,
   statusInSpanish,
-  paymentMethodInSpanish,
-  SinpeData,
-  OrderSettings
+  paymentMethodInSpanish
 } from './src/order/order';
 export {Rating} from './src/rating/rating';
 export {AverageRating} from './src/rating/averageRating';
 export {DeliveryAvailable} from './src/other/deliveryAvailable';
 export {Product} from './src/product/product';
 export {Tag} from './src/product/tag';
-export {ConfigItem} from './src/admin/configItem';
+export {ConfigItem, SinpeData} from './src/admin/configItem';
 export {UserStatus, Coords, UserType} from './src/other/shared';
 /**
  * Colecciones de Firestore
@@ -58,8 +56,5 @@ export enum FirestoreCollections {
   tags = 'tags',
 
   /** Coleccion de {@link ConfigItem} */
-  configItems = 'configItems',
-
-  /** Coleccion de {@link OrderSettings} */
-  orderSettings = 'orderSettings'
+  configItems = 'configItems'
 }

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,9 @@ export {
   OrderStatus,
   PaymentMethod,
   statusInSpanish,
-  paymentMethodInSpanish
+  paymentMethodInSpanish,
+  SinpeData,
+  OrderSettings
 } from './src/order/order';
 export {Rating} from './src/rating/rating';
 export {AverageRating} from './src/rating/averageRating';
@@ -56,5 +58,8 @@ export enum FirestoreCollections {
   tags = 'tags',
 
   /** Coleccion de {@link ConfigItem} */
-  configItems = 'configItems'
+  configItems = 'configItems',
+
+  /** Coleccion de {@link OrderSettings} */
+  orderSettings = 'orderSettings'
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ export { AverageRating } from './src/rating/averageRating';
 export { DeliveryAvailable } from './src/other/deliveryAvailable';
 export { Product } from './src/product/product';
 export { Tag } from './src/product/tag';
-export { ConfigItem } from './src/admin/configItem';
+export { ConfigItem, SinpeData } from './src/admin/configItem';
 export { UserStatus, Coords, UserType } from './src/other/shared';
 /**
  * Colecciones de Firestore

--- a/lib/src/admin/configItem.d.ts
+++ b/lib/src/admin/configItem.d.ts
@@ -14,4 +14,21 @@ export interface ConfigItem {
     facebook: string;
     /** URL de instagram oficial de la aplicación RIDE */
     instragram: string;
+    /** objeto con los datos de sinpe móvil - ver {@link SinpeData}*/
+    sinpeData: SinpeData;
+    /** valor real del monto que se cobra por kilómetro */
+    kilometerPrice: number;
+}
+/**
+ * Representa la información de sinpe móvil donde el usuario puede realizar el pago
+ */
+export interface SinpeData {
+    /** cédula jurídica, física, dimex o otras de la persona dueña de la cuenta */
+    ownerId: string;
+    /** nombre de la persona dueña de la cuenta */
+    firstName: string;
+    /** apellidos de la persona dueña de la cuenta */
+    lastName: string;
+    /** número de teléfono a al que está asociada la cuenta */
+    phoneNumber: string;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ride-dbtypes",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Proyecto RIDE: Documentos NoSQL para Firestore",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ride-dbtypes",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Proyecto RIDE: Documentos NoSQL para Firestore",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/admin/configItem.ts
+++ b/src/admin/configItem.ts
@@ -1,23 +1,46 @@
 /** Configuración general sobre RIDE */
-export interface ConfigItem{
-    /** nombre de la aplicación RIDE */
-    name: string;
+export interface ConfigItem {
+  /** nombre de la aplicación RIDE */
+  name: string;
 
-    /** da información sobre la aplicación RIDE */
-    description: string;
+  /** da información sobre la aplicación RIDE */
+  description: string;
 
-    /** número de emergencia para comunicarse con RIDE dashboard */
-    phoneEmergency: string;
+  /** número de emergencia para comunicarse con RIDE dashboard */
+  phoneEmergency: string;
 
-    /** número para obtener información sobre la aplicación RIDE */
-    phoneInformation: string;
-    
-    /** correo electrónico oficial de la aplicación RIDE */
-    email: string;
-    
-    /** URL de facebook oficial de la aplicación RIDE */
-    facebook: string;
-    
-    /** URL de instagram oficial de la aplicación RIDE */
-    instragram: string;
+  /** número para obtener información sobre la aplicación RIDE */
+  phoneInformation: string;
+
+  /** correo electrónico oficial de la aplicación RIDE */
+  email: string;
+
+  /** URL de facebook oficial de la aplicación RIDE */
+  facebook: string;
+
+  /** URL de instagram oficial de la aplicación RIDE */
+  instragram: string;
+
+  /** objeto con los datos de sinpe móvil - ver {@link SinpeData}*/
+  sinpeData: SinpeData;
+
+  /** valor real del monto que se cobra por kilómetro */
+  kilometerPrice: number;
+}
+
+/**
+ * Representa la información de sinpe móvil donde el usuario puede realizar el pago
+ */
+export interface SinpeData {
+  /** cédula jurídica, física, dimex o otras de la persona dueña de la cuenta */
+  ownerId: string;
+
+  /** nombre de la persona dueña de la cuenta */
+  firstName: string;
+
+  /** apellidos de la persona dueña de la cuenta */
+  lastName: string;
+
+  /** número de teléfono a al que está asociada la cuenta */
+  phoneNumber: string;
 }

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -132,3 +132,33 @@ export interface Order {
   /** Reporte del ciclista */
   reportByBiker: string;
 }
+
+/**
+ * Representa la información de sinpe móvil donde el usuario puede realizar el pago
+ */
+export interface SinpeData {
+
+  /** cédula jurídica, física, dimex o otras de la persona dueña de la cuenta */
+  ownerId: string;
+
+  /** nombre de la persona dueña de la cuenta */
+  firstName: string;
+
+  /** apellidos de la persona dueña de la cuenta */
+  lastName: string;
+
+  /** número de teléfono a al que está asociada la cuenta */
+  phoneNumber: string;
+}
+
+/**
+ * Representa la configuración de las órdenes
+ * Especificamente se configura el precio por kilómetro y los donde pagar
+ */
+export interface OrderSettings {
+  /** objeto con los datos de sinpe móvil - ver {@link SinpeData}*/
+  sinpeData: SinpeData;
+
+  /** valor real del monto que se cobra por kilómetro */
+  kilometerPrice: number;
+}

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -132,33 +132,3 @@ export interface Order {
   /** Reporte del ciclista */
   reportByBiker: string;
 }
-
-/**
- * Representa la información de sinpe móvil donde el usuario puede realizar el pago
- */
-export interface SinpeData {
-
-  /** cédula jurídica, física, dimex o otras de la persona dueña de la cuenta */
-  ownerId: string;
-
-  /** nombre de la persona dueña de la cuenta */
-  firstName: string;
-
-  /** apellidos de la persona dueña de la cuenta */
-  lastName: string;
-
-  /** número de teléfono a al que está asociada la cuenta */
-  phoneNumber: string;
-}
-
-/**
- * Representa la configuración de las órdenes
- * Especificamente se configura el precio por kilómetro y los donde pagar
- */
-export interface OrderSettings {
-  /** objeto con los datos de sinpe móvil - ver {@link SinpeData}*/
-  sinpeData: SinpeData;
-
-  /** valor real del monto que se cobra por kilómetro */
-  kilometerPrice: number;
-}


### PR DESCRIPTION
Jira: [User story RW-27](https://gatitolabs.atlassian.net/browse/RW-27?atlOrigin=eyJpIjoiZDkwZGViZTViMTU4NDhjMTg0NjdhNWY1NTcwYzhhN2YiLCJwIjoiaiJ9)

Added kilometer price and SinpeData object to ConfigItem so the adminitrators can edit this values from Ride-Web and the other apps can consume this info.

SinpeData contains the necessary information to pay with sinpe movil. This data will be displayed in the client app so that the user knows where to pay.
The kilometerPrice will be used in the calculations of the service fee, the idea is that the administrators can edit this value.
